### PR TITLE
Merge Lock Renewal feature to V2

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,0 +1,22 @@
+package redislock
+
+import (
+	"time"
+
+	"github.com/go-redsync/redsync/v4"
+)
+
+type LockerOption func(*redisLocker)
+
+func WithAutoExtendDuration(duration time.Duration) LockerOption {
+	return func(locker *redisLocker) {
+		locker.autoExtendDuration = duration
+	}
+}
+
+// WithRedsyncOptions sets the redsync options.
+func WithRedsyncOptions(options ...redsync.Option) LockerOption {
+	return func(locker *redisLocker) {
+		locker.options = options
+	}
+}

--- a/redislock.go
+++ b/redislock.go
@@ -45,7 +45,7 @@ func NewRedisLockerAlways(r redis.UniversalClient, options ...redsync.Option) (g
 
 func NewRedisLockerWithOptions(r redis.UniversalClient, options ...LockerOption) (gocron.Locker, error) {
 	if err := r.Ping(context.Background()).Err(); err != nil {
-		return nil, fmt.Errorf("%s: %w", gocron.ErrFailedToConnectToRedis, err)
+		return nil, fmt.Errorf("%s: %w", ErrFailedToConnectToRedis, err)
 	}
 	return newLockerWithOptions(r, options...), nil
 }

--- a/redislock.go
+++ b/redislock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-co-op/gocron/v2"
 	"github.com/go-redsync/redsync/v4"
@@ -42,17 +43,36 @@ func NewRedisLockerAlways(r redis.UniversalClient, options ...redsync.Option) (g
 	return newLocker(r, options...), r.Ping(context.Background()).Err()
 }
 
+func NewRedisLockerWithOptions(r redis.UniversalClient, options ...LockerOption) (gocron.Locker, error) {
+	if err := r.Ping(context.Background()).Err(); err != nil {
+		return nil, fmt.Errorf("%s: %w", gocron.ErrFailedToConnectToRedis, err)
+	}
+	return newLockerWithOptions(r, options...), nil
+}
+
 func newLocker(r redis.UniversalClient, options ...redsync.Option) gocron.Locker {
 	pool := goredis.NewPool(r)
 	rs := redsync.New(pool)
 	return &redisLocker{rs: rs, options: options}
 }
 
+func newLockerWithOptions(r redis.UniversalClient, options ...LockerOption) gocron.Locker {
+	pool := goredis.NewPool(r)
+	rs := redsync.New(pool)
+	l := &redisLocker{rs: rs}
+	for _, option := range options {
+		option(l)
+	}
+
+	return l
+}
+
 var _ gocron.Locker = (*redisLocker)(nil)
 
 type redisLocker struct {
-	rs      *redsync.Redsync
-	options []redsync.Option
+	rs                 *redsync.Redsync
+	options            []redsync.Option
+	autoExtendDuration time.Duration
 }
 
 func (r *redisLocker) Lock(ctx context.Context, key string) (gocron.Lock, error) {
@@ -62,7 +82,13 @@ func (r *redisLocker) Lock(ctx context.Context, key string) (gocron.Lock, error)
 		return nil, ErrFailedToObtainLock
 	}
 	rl := &redisLock{
-		mu: mu,
+		mu:                 mu,
+		autoExtendDuration: r.autoExtendDuration,
+		done:               make(chan struct{}),
+	}
+
+	if r.autoExtendDuration > 0 {
+		go func() { rl.doExtend() }()
 	}
 	return rl, nil
 }
@@ -70,10 +96,13 @@ func (r *redisLocker) Lock(ctx context.Context, key string) (gocron.Lock, error)
 var _ gocron.Lock = (*redisLock)(nil)
 
 type redisLock struct {
-	mu *redsync.Mutex
+	mu                 *redsync.Mutex
+	done               chan struct{}
+	autoExtendDuration time.Duration
 }
 
 func (r *redisLock) Unlock(ctx context.Context) error {
+	close(r.done)
 	unlocked, err := r.mu.UnlockContext(ctx)
 	if err != nil {
 		return ErrFailedToReleaseLock
@@ -83,4 +112,19 @@ func (r *redisLock) Unlock(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (r *redisLock) doExtend() {
+	ticker := time.NewTicker(r.autoExtendDuration)
+	for {
+		select {
+		case <-r.done:
+			return
+		case <-ticker.C:
+			_, err := r.mu.Extend()
+			if err != nil {
+				return
+			}
+		}
+	}
 }

--- a/redislock_test.go
+++ b/redislock_test.go
@@ -67,3 +67,47 @@ func TestEnableDistributedLocking(t *testing.T) {
 	}
 	assert.Len(t, results, 4)
 }
+
+func TestAutoExtend(t *testing.T) {
+	ctx := context.Background()
+	redisContainer, err := testcontainersredis.RunContainer(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := redisContainer.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate container: %s", err)
+		}
+	})
+
+	uri, err := redisContainer.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	redisClient := redis.NewClient(&redis.Options{Addr: strings.TrimPrefix(uri, "redis://")})
+	// create lock not auto extend
+	l1, err := NewRedisLockerWithOptions(redisClient, WithRedsyncOptions(WithTries(1)))
+	require.NoError(t, err)
+	_, err = l1.Lock(ctx, "test1")
+	require.NoError(t, err)
+
+	t.Logf("waiting 9 seconds for lock to expire")
+	// wait for the lock to expire
+	time.Sleep(9 * time.Second)
+
+	_, err = l1.Lock(ctx, "test1")
+	require.NoError(t, err)
+
+	// create auto extend lock
+	l2, err := NewRedisLockerWithOptions(redisClient, WithAutoExtendDuration(time.Second*2), WithRedsyncOptions(WithTries(1)))
+	require.NoError(t, err)
+	unlocker, err := l2.Lock(ctx, "test2")
+	require.NoError(t, err)
+
+	t.Log("waiting 9 seconds for lock to expire")
+	// wait for the lock to expire
+	time.Sleep(9 * time.Second)
+
+	_, err = l2.Lock(ctx, "test2")
+	require.Equal(t, gocron.ErrFailedToObtainLock, err)
+
+	err = unlocker.Unlock(ctx)
+	require.NoError(t, err)
+}

--- a/redislock_test.go
+++ b/redislock_test.go
@@ -106,7 +106,7 @@ func TestAutoExtend(t *testing.T) {
 	time.Sleep(9 * time.Second)
 
 	_, err = l2.Lock(ctx, "test2")
-	require.Equal(t, gocron.ErrFailedToObtainLock, err)
+	require.Equal(t, ErrFailedToObtainLock, err)
 
 	err = unlocker.Unlock(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
### What does this do?

A previous PR (https://github.com/go-co-op/gocron-redis-lock/pull/55) which has been merged to v1 adds support for extending lock duration if the job is not completed within expected time frame. This PR cherry-picks contents of that branch and merges them to v2 branch with very minor adjustments to used errors.

### Which issue(s) does this PR fix/relate to?
https://github.com/go-co-op/gocron-redis-lock/issues/54

### List any changes that modify/break current functionality

### Have you included tests for your changes?

### Did you document any new/modified functionality?

- [] Updated `example_test.go`
- [] Updated `README.md`

### Notes
