### PR TITLE
Fix ticker leak when unlocking with auto extend

### DIFF
--- a/redislock.go
+++ b/redislock.go
@@ -119,6 +119,8 @@ func (r *redisLock) Unlock(ctx context.Context) error {
 
 func (r *redisLock) doExtend() {
 	ticker := time.NewTicker(r.autoExtendDuration)
+	defer ticker.Stop()
+
 	for {
 		select {
 		case <-r.done:


### PR DESCRIPTION
### What does this do?
Fix `time.Ticker` leak when unlocking redis lock with `WithAutoExtendDuration `

### Which issue(s) does this PR fix/relate to?
Fix #136 



### List any changes that modify/break current functionality
Bug fix, no functionality changes
